### PR TITLE
chore: rename future base exception

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -20,7 +20,7 @@ csharp:
   version: 1.1.0
   additionalDependencies: []
   author: Formance
-  baseErrorName: FormanceError
+  baseErrorName: SDKBaseException
   clientServerStatusCodesAsErrors: true
   defaultErrorName: SDKException
   disableNamespacePascalCasingApr2024: true


### PR DESCRIPTION
In an upcoming release, all SDK exceptions will inherit from a _base_ exception to ease error handling. Given that the _default_ exception is currently named `SDKException`, this PR aims at improving naming consistency by editing the `baseErrorName` configuration parameter. Note this configuration change is a no-op for now and will only have effect once the new Error handling feature is released.
